### PR TITLE
Cannot resolve symbol 'ActivityCompat' and support scanning other formats of barcode

### DIFF
--- a/src/android/QRScanner.java
+++ b/src/android/QRScanner.java
@@ -24,7 +24,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import android.hardware.Camera;
 import android.provider.Settings;
-import android.support.v4.app.ActivityCompat;
+import androidx.core.app.ActivityCompat;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 

--- a/src/android/QRScanner.java
+++ b/src/android/QRScanner.java
@@ -455,7 +455,22 @@ public class QRScanner extends CordovaPlugin implements BarcodeCallback {
 
                 //Configure the decoder
                 ArrayList<BarcodeFormat> formatList = new ArrayList<BarcodeFormat>();
+                formatList.add(BarcodeFormat.AZTEC);
+                formatList.add(BarcodeFormat.CODABAR);
+                formatList.add(BarcodeFormat.CODE_128);
+                formatList.add(BarcodeFormat.CODE_39);
+                formatList.add(BarcodeFormat.CODE_93);
+                formatList.add(BarcodeFormat.DATA_MATRIX);
+                formatList.add(BarcodeFormat.EAN_13);
+                formatList.add(BarcodeFormat.EAN_8);
+                formatList.add(BarcodeFormat.ITF);
+                formatList.add(BarcodeFormat.PDF_417);
                 formatList.add(BarcodeFormat.QR_CODE);
+                formatList.add(BarcodeFormat.RSS_14);
+                formatList.add(BarcodeFormat.RSS_EXPANDED);
+                formatList.add(BarcodeFormat.UPC_A);
+                formatList.add(BarcodeFormat.UPC_E);
+                formatList.add(BarcodeFormat.UPC_EAN_EXTENSION);
                 mBarcodeView.setDecoderFactory(new DefaultDecoderFactory(formatList, null, null));
 
                 //Configure the camera (front/back)


### PR DESCRIPTION
- fix Cannot resolve symbol 'ActivityCompat' error in QRScanner.java
- feat: support scanning other formats of barcode