### PR TITLE
removed android:required="false" from androids "uses-permission" tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
       </feature>
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/*">
-      <uses-permission android:name="android.permission.CAMERA" android:required="false" />
+      <uses-permission android:name="android.permission.CAMERA" />
       <uses-feature android:name="android.hardware.camera" android:required="false" />
       <uses-feature android:name="android.hardware.camera.front" android:required="false" />
     </config-file>


### PR DESCRIPTION
"uses-permission" tag has no "required" attribute (https://developer.android.com/guide/topics/manifest/uses-permission-element). see also: https://github.com/bitpay/cordova-plugin-qrscanner/issues/111